### PR TITLE
Refactor: 포인트 만료 처리 기능 위치 변경, 테이블 명명 수정

### DIFF
--- a/http/Point.http
+++ b/http/Point.http
@@ -114,11 +114,6 @@ X-USER-ID: {{userId}}
 }
 
 
-### 2-8. 포인트 만료 처리 (해당 유저 만료 즉시 반영)
-POST {{host}}/users/me/points/expire?userId={{userId}}
-X-USER-ID: {{adminId}}
-
-
 ########################################################
 # 3. ADMIN POINT HISTORY API (관리자 조회 / 조정)
 ########################################################
@@ -144,3 +139,6 @@ X-USER-ID: {{adminId}}
   "memo": "고객센터 보상 지급 테스트"
 }
 
+### 3-4. (관리자) 포인트 만료 처리 (해당 유저 만료 즉시 반영)
+POST {{host}}/admin/points/expire?userId={{userId}}
+X-USER-ID: {{adminId}}

--- a/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryAdminController.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryAdminController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,7 +31,7 @@ public class PointHistoryAdminController {
     // GET /admin/points?userId=1
     @GetMapping
     public Page<PointHistoryResponseDto> getUserPointHistory(
-            @RequestHeader(USER_ID_HEADER) Long adminUserId, // adminUserId: 이 API를 호출한 관리자 ID
+            @RequestHeader(USER_ID_HEADER) Long adminUserId, // == userId / adminUserId: 이 API를 호출한 관리자 ID
             @RequestParam Long userId,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
@@ -57,5 +58,13 @@ public class PointHistoryAdminController {
         // requestDto.getUserId() : 포인트 조정 대상 회원
         // adminUserId           : 이 조정을 실행한 관리자
         return pointHistoryService.adjustPointByAdmin(requestDto);
+    }
+
+    // 4. (관리자) 포인트 만료 처리 (해당 유저에 대해 만료일자가 지난 포인트들을 즉시 만료 처리)
+    // POST /users/me/points/expire?userId=1
+    @PostMapping("/expire")
+    public ResponseEntity<Void> expirePoints(@RequestHeader(USER_ID_HEADER) Long userId) {
+        pointHistoryService.expirePoints(userId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryUserController.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryUserController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -106,13 +105,5 @@ public class PointHistoryUserController {
             throw new IllegalArgumentException("요청 userId와 인증된 사용자가 일치하지 않습니다.");
         }
         return pointHistoryService.refundPoint(dto);
-    }
-
-    // 6. 포인트 만료 처리 (해당 유저에 대해 만료일자가 지난 포인트들을 즉시 만료 처리)
-    // POST /users/me/points/expire?userId=1
-    @PostMapping("/expire")
-    public ResponseEntity<Void> expirePoints(@RequestHeader(USER_ID_HEADER) Long userId) {
-        pointHistoryService.expirePoints(userId);
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/book2onandonuserservice/point/domain/entity/PointHistory.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/domain/entity/PointHistory.java
@@ -26,7 +26,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "PointHistory")
+@Table(name = "point_history")
 public class PointHistory {
 
     @Id

--- a/src/main/java/com/example/book2onandonuserservice/point/domain/entity/PointPolicy.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/domain/entity/PointPolicy.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "PointPolicy")
+@Table(name = "point_policy")
 public class PointPolicy {
 
     @Id


### PR DESCRIPTION
## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.

- 포인트 만료 처리 기능 위치 변경
- 포인트 만료 처리 기능 위치 변경에 따른 http테스트 경로 변경
- Entity 테이블 명명 수정

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [ ] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

- 포인트 만료 처리(expirePoints)의 위치를 PointHistoryUserController -> PointHistoryAdminController로 변경
- @Table(name)에서 이름을 PointPolicy -> point_policy, PointHistory -> point_history 로 수정

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.

- 포인트 만료 기능의 경우 User보다 Admin에 적합하기에 위치 변경
- 포인트 만료 처리 기능 위치 변경에 따른 http테스트 경로 변경
- 팀 명명 규칙에 따르기 위한 @Table(name) 수정

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  
예시:

- [Point] - 포인트 만료 처리 위치 변경, @Table name 수정 #50

---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.

예시:

```bash
# 로컬 서버 실행
npm run dev
# 또는
python manage.py runserver
