### PR TITLE
Feat/ Redis blacklist

### DIFF
--- a/src/main/java/com/example/book2onandonuserservice/auth/controller/AuthController.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -51,6 +52,16 @@ public class AuthController {
     ) {
         TokenResponseDto tokenResponse = authService.loginWithPayco(request);
         return ResponseEntity.ok(tokenResponse);
+    }
+
+    //로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String accessToken) {
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            String token = accessToken.substring(7);
+            authService.logout(token);
+        }
+        return ResponseEntity.ok().build();
     }
 
     //아이디찾기

--- a/src/main/java/com/example/book2onandonuserservice/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/domain/entity/RefreshToken.java
@@ -1,0 +1,15 @@
+package com.example.book2onandonuserservice.auth.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "refreshToken", timeToLive = 604800)
+public class RefreshToken {
+    @Id
+    private String userId;
+    private String token;
+}

--- a/src/main/java/com/example/book2onandonuserservice/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.example.book2onandonuserservice.auth.jwt;
 import com.example.book2onandonuserservice.auth.domain.dto.request.TokenRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.response.TokenResponseDto;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -21,14 +22,12 @@ public class JwtTokenProvider {
                             @Value("${jwt.access-token-validity}") long accessValidity,
                             @Value("${jwt.refresh-token-validity}") long refreshValidity) {
         byte[] keyBytes = secret.getBytes();
-
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
-
         this.accessTokenValidityInMilliseconds = accessValidity * 1000;
         this.refreshTokenValidityInMilliseconds = refreshValidity * 1000;
     }
 
-    //인증 성공 시 AccessToken, RefreshToken 생성
+    // 인증 성공 시 AccessToken, RefreshToken 생성
     public TokenResponseDto createTokens(TokenRequestDto tokenRequest) {
         String accessToken = createAccessToken(tokenRequest);
         String refreshToken = createRefreshToken();
@@ -68,4 +67,36 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public String getUserId(String token) {
+        return parseClaims(token).get("userId").toString();
+    }
+
+    public String getRole(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    public long getExpiration(String token) {
+        return parseClaims(token).getExpiration().getTime();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
 }

--- a/src/main/java/com/example/book2onandonuserservice/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.book2onandonuserservice.auth.repository;
+
+import com.example.book2onandonuserservice.auth.domain.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/com/example/book2onandonuserservice/auth/service/AuthService.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/service/AuthService.java
@@ -19,9 +19,12 @@ public interface AuthService {
     //PAYCO 로그인
     TokenResponseDto loginWithPayco(PaycoLoginRequestDto request);
 
+    //로그아웃
+    void logout(String accessToken);
+
     //아이디찾기
     FindIdResponseDto findId(FindIdRequestDto request);
 
-    //임시비밀본호
+    //임시비밀번호
     void issueTemporaryPassword(FindPasswordRequestDto request);
 }

--- a/src/main/java/com/example/book2onandonuserservice/global/util/RedisUtil.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/util/RedisUtil.java
@@ -1,0 +1,20 @@
+package com.example.book2onandonuserservice.global.util;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final StringRedisTemplate redisTemplate;
+
+    public void setBlackList(String key, Object o, Long minutes) {
+        redisTemplate.opsForValue().set(key, o.toString(), minutes, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean hasKeyBlackList(String key) {
+        return redisTemplate.hasKey(key);
+    }
+}


### PR DESCRIPTION
## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.
Redis 블랙리스트 구현

예시:

- 로그인 API 응답 포맷 수정
- 도서 상세 페이지 스타일링 개선

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.
기존 프론트에서 쿠키를 삭제해서 로그아웃하는 구조에서 
로그아웃시 토큰을 redis에 등록해서 블랙리스트로 등록시키도록 변경했습니다.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.
기존 방식에서 로그아웃을 해도 서버에서 accesstoken, refresh토큰 시간이 만료되기 전까지 토큰이 살아있었는데 
redis blacklist를 적용함으로써 로그아웃시 redis에 토큰을 등록시킴으로써 탈취한 토큰으로 로그인 시도시 블랙리스트로 등록하도록 로직을 구현함.

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  
예시:

#55 

---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.

예시:

```bash
# 로컬 서버 실행
npm run dev
# 또는
python manage.py runserver
