### PR TITLE
Feat: 회원탈퇴 시 보유 포인트 0으로 강제, 이번달 적립/사용 정보 응답(프론트) 구현

### DIFF
--- a/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryUserController.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryUserController.java
@@ -8,6 +8,7 @@ import com.example.book2onandonuserservice.point.domain.dto.response.CurrentPoin
 import com.example.book2onandonuserservice.point.domain.dto.response.EarnPointResponseDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.ExpiringPointResponseDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.PointHistoryResponseDto;
+import com.example.book2onandonuserservice.point.domain.dto.response.PointSummaryResponseDto;
 import com.example.book2onandonuserservice.point.service.PointHistoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -65,19 +66,6 @@ public class PointHistoryUserController {
 
     // 3-2. 리뷰 작성 적립 (일반/사진)
     // POST /users/me/points/earn/review
-//    @PostMapping("/earn/review")
-//    public ResponseEntity<EarnPointResponseDto> earnReviewPoint(
-//            @RequestHeader(USER_ID_HEADER) Long userId,
-//            @Valid @RequestBody EarnReviewPointRequestDto dto
-//    ) {
-//        // "me" 보장: Body 안에 userId가 있다면 헤더와 일치하는지 검증
-//        if (dto.getUserId() != null && !dto.getUserId().equals(userId)) {
-//            throw new UserIdMismatchException(userId);
-//        }
-//        dto.setUserId(userId);
-//        EarnPointResponseDto earnPoint = pointHistoryService.earnReviewPoint(dto);
-//        return ResponseEntity.ok(earnPoint);
-//    }
     @PostMapping("/earn/review")
     public ResponseEntity<EarnPointResponseDto> earnReviewPoint(
             @RequestHeader(USER_ID_HEADER) Long userId,
@@ -86,6 +74,7 @@ public class PointHistoryUserController {
         if (dto.getUserId() != null && !dto.getUserId().equals(userId)) {
             throw new IllegalArgumentException("요청 userId와 인증된 사용자가 일치하지 않습니다.");
         }
+        dto.setUserId(userId);
         EarnPointResponseDto earnPoint = pointHistoryService.earnReviewPoint(dto);
         return ResponseEntity.ok(earnPoint);
     }
@@ -130,6 +119,7 @@ public class PointHistoryUserController {
         if (dto.getUserId() != null && !dto.getUserId().equals(userId)) {
             throw new IllegalArgumentException("요청 userId와 인증된 사용자가 일치하지 않습니다.");
         }
+        dto.setUserId(userId);
         EarnPointResponseDto earnPoint = pointHistoryService.refundPoint(dto);
         return ResponseEntity.ok(earnPoint);
     }
@@ -144,4 +134,14 @@ public class PointHistoryUserController {
         ExpiringPointResponseDto expiringPoints = pointHistoryService.getExpiringPoints(userId, days);
         return ResponseEntity.ok().body(expiringPoints);
     }
+
+    // 7. 포인트 내역 요약 (프론트)
+    @GetMapping("/summary")
+    public ResponseEntity<PointSummaryResponseDto> getSummary(
+            @RequestHeader(USER_ID_HEADER) Long userId
+    ) {
+        PointSummaryResponseDto dto = pointHistoryService.getMyPointSummary(userId);
+        return ResponseEntity.ok(dto);
+    }
+
 }

--- a/src/main/java/com/example/book2onandonuserservice/point/domain/dto/response/ExpiringPointResponseDto.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/domain/dto/response/ExpiringPointResponseDto.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-// 7일 내 소멸 예정 포인트 조회
 public class ExpiringPointResponseDto {
     private int expiringAmount;
     private LocalDateTime fromDate;

--- a/src/main/java/com/example/book2onandonuserservice/point/domain/dto/response/PointSummaryResponseDto.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/domain/dto/response/PointSummaryResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.book2onandonuserservice.point.domain.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PointSummaryResponseDto {
+
+    private int totalPoint;       // 현재 보유 포인트
+    private int earnedThisMonth;  // 이번달 적립
+    private int usedThisMonth;    // 이번달 사용
+    private int expiringSoon;     // 7일 내 소멸 예정 포인트
+    private LocalDateTime from;   // 이번달 시작일
+    private LocalDateTime to;     // 기준일
+}

--- a/src/main/java/com/example/book2onandonuserservice/point/domain/entity/PointReason.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/domain/entity/PointReason.java
@@ -8,5 +8,6 @@ public enum PointReason {
     REFUND, // 주문 취소/반품으로 인한 반환
     FAILED, //
     EXPIRE, // 만료
+    WITHDRAW, // 회원탈퇴
     ADMIN_ADJUST // 관리자 수동 지급/차감
 }

--- a/src/main/java/com/example/book2onandonuserservice/point/repository/PointHistoryRepository.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/repository/PointHistoryRepository.java
@@ -62,5 +62,30 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
     List<PointHistory> findByUserUserIdAndPointExpiredDateBetweenAndRemainingPointGreaterThan(
             Long userId, LocalDateTime from, LocalDateTime to, int minRemainingPoint);
 
+    // 회원탈퇴 시 포인트 0으로 강제 처리
+    List<PointHistory> findByUserUserIdAndPointHistoryChangeGreaterThanAndRemainingPointGreaterThan(Long userId,
+                                                                                                    int minChange,
+                                                                                                    int minRemainingPoint);
+
+    // 이번 달 적립 합계
+    @Query("""
+            SELECT COALESCE(SUM(ph.pointHistoryChange), 0)
+            FROM PointHistory ph
+            WHERE ph.user.userId = :userId
+              AND ph.pointHistoryChange > 0
+              AND ph.pointCreatedDate BETWEEN :from AND :to
+            """)
+    int sumEarnedInPeriod(Long userId, LocalDateTime from, LocalDateTime to);
+
+    // 이번 달 사용 합계
+    @Query("""
+            SELECT COALESCE(SUM(-ph.pointHistoryChange), 0)
+            FROM PointHistory ph
+            WHERE ph.user.userId = :userId
+              AND ph.pointReason = com.example.book2onandonuserservice.point.domain.entity.PointReason.USE
+              AND ph.pointCreatedDate BETWEEN :from AND :to
+            """)
+    int sumUsedInPeriod(Long userId, LocalDateTime from, LocalDateTime to);
+
 }
 

--- a/src/main/java/com/example/book2onandonuserservice/point/service/PointHistoryService.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/service/PointHistoryService.java
@@ -9,6 +9,7 @@ import com.example.book2onandonuserservice.point.domain.dto.response.CurrentPoin
 import com.example.book2onandonuserservice.point.domain.dto.response.EarnPointResponseDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.ExpiringPointResponseDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.PointHistoryResponseDto;
+import com.example.book2onandonuserservice.point.domain.dto.response.PointSummaryResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -46,6 +47,12 @@ public interface PointHistoryService {
 
     // 8. 관리자 수동 포인트 지급/차감
     EarnPointResponseDto adjustPointByAdmin(PointHistoryAdminAdjustRequestDto requestDto);
+
+    // 9. 회원탈퇴 시 포인트 제거
+    void expireAllPointsForWithdraw(Long userId);
+
+    // 10. 포인트 내역 요약(프론트)
+    PointSummaryResponseDto getMyPointSummary(Long userId);
 }
 
 

--- a/src/main/java/com/example/book2onandonuserservice/point/support/pointHistory/PointHistoryValidator.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/support/pointHistory/PointHistoryValidator.java
@@ -86,4 +86,12 @@ public class PointHistoryValidator {
             throw new PointAlreadyUsedForOrderException(orderId);
         }
     }
+
+    // 8. 회원탈퇴 시 포인트 0으로 강제처리
+    public List<PointHistory> getAllRemainingEarnRows(Long userId) {
+        return pointHistoryRepository
+                .findByUserUserIdAndPointHistoryChangeGreaterThanAndRemainingPointGreaterThan(
+                        userId, 0, 0
+                );
+    }
 }


### PR DESCRIPTION
## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.

예시:

- 회원탈퇴 시 포인트 내역은 남기되 보유한 포인트를 0으로 강제하는 메서드 구현
- 프론트를 위한 이번달 적립/사용포인트 응답 구현

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.

- 프론트의 원활한 출력을 위한 포인트사용요약 제공
- 회원탈퇴 시 포인트 처리 필요

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  
예시:

- Closes #79 

---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.

예시:

```bash
# 로컬 서버 실행
npm run dev
# 또는
python manage.py runserver
