### PR TITLE
Feat/ AuthCheck, 토큰 재발급 분산락 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>3.30.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>

--- a/src/main/java/com/example/book2onandonuserservice/auth/domain/dto/request/ReissueRequestDto.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/domain/dto/request/ReissueRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 
 //AccessToken 재발급 로직
 public record ReissueRequestDto(
-        @NotBlank String accessToken,
+        String accessToken,
         @NotBlank String refreshToken
 ) {
 }

--- a/src/main/java/com/example/book2onandonuserservice/auth/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.example.book2onandonuserservice.auth.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/book2onandonuserservice/auth/service/AuthTokenService.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/service/AuthTokenService.java
@@ -4,17 +4,20 @@ import com.example.book2onandonuserservice.auth.domain.dto.request.ReissueReques
 import com.example.book2onandonuserservice.auth.domain.dto.request.TokenRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.response.TokenResponseDto;
 import com.example.book2onandonuserservice.auth.domain.entity.RefreshToken;
+import com.example.book2onandonuserservice.auth.exception.InvalidRefreshTokenException;
 import com.example.book2onandonuserservice.auth.jwt.JwtTokenProvider;
 import com.example.book2onandonuserservice.auth.repository.redis.RefreshTokenRepository;
 import com.example.book2onandonuserservice.global.util.RedisKeyPrefix;
 import com.example.book2onandonuserservice.global.util.RedisUtil;
 import com.example.book2onandonuserservice.user.domain.entity.Users;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthTokenService {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -38,42 +41,79 @@ public class AuthTokenService {
 
     // AccessToken 재발급 로직
     public TokenResponseDto reissueToken(ReissueRequestDto request) {
-        if (!jwtTokenProvider.validateToken(request.refreshToken())) {
-            throw new IllegalArgumentException("유효하지 않은 RefreshToken입니다.");
+        // [RTR 로그 1] 요청 들어온 토큰 확인 (보안을 위해 끝 10자리만 출력)
+        String reqToken = request.refreshToken();
+        String reqTokenTail = reqToken.length() > 10 ? reqToken.substring(reqToken.length() - 10) : reqToken;
+        log.info(" [RTR 요청] 교체 대상 토큰(Old): ...{}", reqTokenTail);
+
+        if (!jwtTokenProvider.validateToken(reqToken)) {
+            throw new InvalidRefreshTokenException("유효하지 않은 RefreshToken입니다.");
         }
-        String userId = jwtTokenProvider.getUserId(request.refreshToken());
+
+        String userId = jwtTokenProvider.getUserId(reqToken);
         RefreshToken storedToken = refreshTokenRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("저장된 Refresh 토큰이 없습니다. 다시 로그인 하세요."));
+                .orElseThrow(() -> new InvalidRefreshTokenException("저장된 Refresh 토큰이 없습니다. 다시 로그인 하세요."));
 
-        if (!storedToken.getToken().equals(request.refreshToken())) {
-            throw new IllegalArgumentException("RefreshToken이 일치하지 않습니다.");
+        // [검증] 저장된 토큰과 요청 토큰 불일치 (재사용 감지 or 동시성 문제)
+        if (!storedToken.getToken().equals(reqToken)) {
+            String dbToken = storedToken.getToken();
+            String dbTokenTail = dbToken.length() > 10 ? dbToken.substring(dbToken.length() - 10) : dbToken;
+
+            log.error(" [RTR 실패] 토큰 불일치 발생!");
+            log.error(" - 요청 토큰(Old): ...{}", reqTokenTail);
+            log.error(" - DB 토큰(Current): ...{}", dbTokenTail);
+
+            throw new InvalidRefreshTokenException("RefreshToken이 일치하지 않습니다.");
         }
-        String role = jwtTokenProvider.getRole(request.refreshToken());
-        TokenRequestDto tokenRequest = new TokenRequestDto(Long.parseLong(userId), role);
 
+        // 새 토큰 생성
+        String role = jwtTokenProvider.getRole(reqToken);
+        TokenRequestDto tokenRequest = new TokenRequestDto(Long.parseLong(userId), role);
         TokenResponseDto newToken = jwtTokenProvider.createTokens(tokenRequest);
 
-        // Redis에 새 RefreshToken 발급하며 보안강화
+        // DB 업데이트
         RefreshToken newRefreshToken = new RefreshToken(userId, newToken.refreshToken());
         refreshTokenRepository.save(newRefreshToken);
+
+        // [RTR 로그 2] 새로 발급된 토큰 확인
+        String newTokenStr = newToken.refreshToken();
+        String newTokenTail =
+                newTokenStr.length() > 10 ? newTokenStr.substring(newTokenStr.length() - 10) : newTokenStr;
+        log.info(" [RTR 완료] 새 토큰 발급 및 저장(New): ...{}", newTokenTail);
+
         return newToken;
     }
 
     //로그아웃
     @Transactional
     public void logout(String accessToken) {
+        if (accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+
         long expiration = jwtTokenProvider.getExpiration(accessToken);
         long now = System.currentTimeMillis();
         long remainingTime = expiration - now;
 
+        log.info(" [로그아웃 시도]");
+        log.info(" - 토큰 남은 시간(ms): {}", remainingTime);
+
         if (remainingTime > 0) {
             String blackListKey = RedisKeyPrefix.BLACKLIST.buildKey(accessToken);
+
+            // 확인용 로그: 실제 저장되는 Redis Key 확인
+            log.info(" - Redis Key 생성됨: {}", blackListKey);
+
             redisUtil.setBlackList(blackListKey, "logout", remainingTime);
+            log.info(" - 블랙리스트 저장 완료");
+        } else {
+            log.warn(" - 이미 만료된 토큰입니다. 블랙리스트에 저장하지 않습니다.");
         }
 
         String userId = jwtTokenProvider.getUserId(accessToken);
         if (userId != null) {
             refreshTokenRepository.deleteById(userId);
+            log.info(" - Refresh Token 삭제 완료 (User ID: {})", userId);
         }
     }
 

--- a/src/main/java/com/example/book2onandonuserservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/book2onandonuserservice/auth/service/impl/AuthServiceImpl.java
@@ -15,6 +15,7 @@ import com.example.book2onandonuserservice.auth.service.AuthService;
 import com.example.book2onandonuserservice.auth.service.AuthTokenService;
 import com.example.book2onandonuserservice.auth.service.AuthVerificationService;
 import com.example.book2onandonuserservice.auth.service.PaycoAuthService;
+import com.example.book2onandonuserservice.global.annotation.DistributedLock;
 import com.example.book2onandonuserservice.global.event.EmailSendEvent;
 import com.example.book2onandonuserservice.global.util.RedisKeyPrefix;
 import com.example.book2onandonuserservice.global.util.RedisUtil;
@@ -97,7 +98,8 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    @Transactional
+    @DistributedLock(key = "'REISSUE_TOKEN:' + #request.refreshToken") //RefreshToken 값을 기준으로 락 설정
+    @Transactional // 순서: Lock 획득 -> Transaction 시작 -> 로직 수행 -> Transaction 커밋 -> Lock 해제
     public TokenResponseDto reissue(ReissueRequestDto request) {
         return authTokenService.reissueToken(request);
     }

--- a/src/main/java/com/example/book2onandonuserservice/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.example.book2onandonuserservice.address.exception.AddressLimitExceede
 import com.example.book2onandonuserservice.address.exception.AddressNameDuplicateException;
 import com.example.book2onandonuserservice.address.exception.AddressNotFoundException;
 import com.example.book2onandonuserservice.auth.exception.AuthenticationFailedException;
+import com.example.book2onandonuserservice.auth.exception.InvalidRefreshTokenException;
 import com.example.book2onandonuserservice.auth.exception.PaycoInfoMissingException;
 import com.example.book2onandonuserservice.auth.exception.PaycoServerException;
 import com.example.book2onandonuserservice.global.dto.ErrorResponse;
@@ -125,6 +126,15 @@ public class GlobalExceptionHandler {
     })
     public ResponseEntity<ErrorResponse> handleAuthenticationFailed(RuntimeException ex) {
         return buildErrorResponse(HttpStatus.UNAUTHORIZED, "AUTH_FAILED", ex.getMessage());
+    }
+
+    /**
+     * [401] Refresh Token 유효성 검사 실패 (재로그인 필요)
+     */
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRefreshTokenException(InvalidRefreshTokenException ex) {
+        log.warn("Invalid Refresh Token: {}", ex.getMessage());
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", ex.getMessage());
     }
 
     /**

--- a/src/main/java/com/example/book2onandonuserservice/global/annotation/AuthCheck.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/annotation/AuthCheck.java
@@ -1,0 +1,13 @@
+package com.example.book2onandonuserservice.global.annotation;
+
+import com.example.book2onandonuserservice.user.domain.entity.Role;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthCheck {
+    Role[] value();
+}

--- a/src/main/java/com/example/book2onandonuserservice/global/annotation/DistributedLock.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/annotation/DistributedLock.java
@@ -1,0 +1,19 @@
+package com.example.book2onandonuserservice.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String key();
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 10L;
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/com/example/book2onandonuserservice/global/aop/AuthCheckAspect.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/aop/AuthCheckAspect.java
@@ -1,0 +1,45 @@
+package com.example.book2onandonuserservice.global.aop;
+
+import com.example.book2onandonuserservice.global.annotation.AuthCheck;
+import com.example.book2onandonuserservice.global.util.UserHeaderUtil;
+import com.example.book2onandonuserservice.user.domain.entity.Role;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthCheckAspect {
+
+    private final UserHeaderUtil userHeaderUtil;
+
+    @Before("@annotation(authCheck)")
+    public void checkRole(AuthCheck authCheck) {
+        String userRoleStr = userHeaderUtil.getUserRole();
+
+        // 1. 로그인 여부 확인 (Role 헤더가 없으면 권한 없음 처리)
+        if (userRoleStr == null || userRoleStr.isBlank()) {
+            throw new AccessDeniedException("권한 정보가 없습니다. (로그인 필요)");
+        }
+
+        // 2. SUPER_ADMIN은 모든 권한 프리패스
+        if (Role.SUPER_ADMIN.getKey().equals(userRoleStr)) {
+            return;
+        }
+
+        // 어노테이션에 명시된 권한 중 하나라도 일치하면 통과
+        boolean hasPermission = Arrays.stream(authCheck.value())
+                .anyMatch(allowedRole -> allowedRole.getKey().equals(userRoleStr));
+
+        if (!hasPermission) {
+            log.warn("권한 없는 접근 시도. User Role: {}, Required: {}", userRoleStr, Arrays.toString(authCheck.value()));
+            throw new AccessDeniedException("해당 리소스에 접근할 권한이 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/book2onandonuserservice/global/aop/DistributedLockAop.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/aop/DistributedLockAop.java
@@ -1,0 +1,59 @@
+package com.example.book2onandonuserservice.global.aop;
+
+import com.example.book2onandonuserservice.global.annotation.DistributedLock;
+import com.example.book2onandonuserservice.global.util.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)// @Transactional 보다 먼저 락이 걸려야함.
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private final RedissonClient redissonClient;
+    private final CustomSpringELParser customSpringELParser;
+
+    @Around("@annotation(distributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+
+        // SpEL을 사용하여 락 키 생성
+        String key = "LOCK: " + customSpringELParser.getDynamicValue(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                distributedLock.key()
+        );
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(
+                    distributedLock.waitTime(),
+                    distributedLock.leaseTime(),
+                    distributedLock.timeUnit()
+            );
+
+            if (!available) {
+                log.warn("Redisson Lock 획득 식패 - key: {}", key);
+                throw new IllegalStateException("현재 처리 중인 요청입니다. 잠시 후 다시 시도해주세요.");
+            }
+
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            if (rLock.isLocked() && rLock.isHeldByCurrentThread()) {
+                rLock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/book2onandonuserservice/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/config/AsyncConfig.java
@@ -1,9 +1,22 @@
 package com.example.book2onandonuserservice.global.config;
 
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync //비동기
 public class AsyncConfig {
+    @Bean(name = "mailExecutor")
+    public Executor mailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);     // 기본 스레드 수
+        executor.setMaxPoolSize(10);     // 최대 스레드 수
+        executor.setQueueCapacity(100);  // 대기 큐 크기
+        executor.setThreadNamePrefix("MailExecutor-"); // 로그에 찍힐 스레드 이름 접두사
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/example/book2onandonuserservice/global/util/CustomSpringELParser.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/util/CustomSpringELParser.java
@@ -1,0 +1,21 @@
+package com.example.book2onandonuserservice.global.util;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomSpringELParser {
+    // 분산 락 키를 만들기 위해 사용하는 Spring Expression Language 파서 유틸리티.
+    public Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/example/book2onandonuserservice/global/util/UserHeaderUtil.java
+++ b/src/main/java/com/example/book2onandonuserservice/global/util/UserHeaderUtil.java
@@ -1,0 +1,41 @@
+package com.example.book2onandonuserservice.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class UserHeaderUtil {
+
+    private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
+
+    public Long getUserId() {
+        HttpServletRequest request = getRequest();
+        if (request == null) {
+            return null;
+        }
+
+        String userIdStr = request.getHeader(HEADER_USER_ID);
+        if (userIdStr == null || userIdStr.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return Long.parseLong(userIdStr);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public String getUserRole() {
+        HttpServletRequest request = getRequest();
+        return (request != null) ? request.getHeader(HEADER_USER_ROLE) : null;
+    }
+
+    private HttpServletRequest getRequest() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        return (attributes != null) ? attributes.getRequest() : null;
+    }
+}

--- a/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryAdminController.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/controller/PointHistoryAdminController.java
@@ -1,10 +1,12 @@
 package com.example.book2onandonuserservice.point.controller;
 
+import com.example.book2onandonuserservice.global.annotation.AuthCheck;
 import com.example.book2onandonuserservice.point.domain.dto.request.PointHistoryAdminAdjustRequestDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.CurrentPointResponseDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.EarnPointResponseDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.PointHistoryResponseDto;
 import com.example.book2onandonuserservice.point.service.PointHistoryService;
+import com.example.book2onandonuserservice.user.domain.entity.Role;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,6 +31,7 @@ public class PointHistoryAdminController {
     // 1. (관리자) 특정 유저의 포인트 전체 이력 조회
     // GET /admin/points
     @GetMapping
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<Page<PointHistoryResponseDto>> getUserPointHistory(
 //            @RequestHeader(USER_ID_HEADER) Long adminUserId, // == userId / adminUserId: 이 API를 호출한 관리자 ID
             @RequestParam Long userId,
@@ -41,6 +44,7 @@ public class PointHistoryAdminController {
     // 2. (관리자) 특정 유저의 현재 보유 포인트 조회
     // GET /admin/points/current
     @GetMapping("/current")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<CurrentPointResponseDto> getUserCurrentPoint(
             @RequestParam Long userId
     ) {
@@ -51,6 +55,7 @@ public class PointHistoryAdminController {
     // 3. (관리자) 수동 포인트 지급/차감
     // POST /admin/points/adjust
     @PostMapping("/adjust")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<EarnPointResponseDto> adjustPointByAdmin(
             @Valid @RequestBody PointHistoryAdminAdjustRequestDto requestDto
     ) {

--- a/src/main/java/com/example/book2onandonuserservice/point/controller/PointPolicyController.java
+++ b/src/main/java/com/example/book2onandonuserservice/point/controller/PointPolicyController.java
@@ -1,9 +1,11 @@
 package com.example.book2onandonuserservice.point.controller;
 
+import com.example.book2onandonuserservice.global.annotation.AuthCheck;
 import com.example.book2onandonuserservice.point.domain.dto.request.PointPolicyActiveUpdateRequestDto;
 import com.example.book2onandonuserservice.point.domain.dto.request.PointPolicyUpdateRequestDto;
 import com.example.book2onandonuserservice.point.domain.dto.response.PointPolicyResponseDto;
 import com.example.book2onandonuserservice.point.service.PointPolicyService;
+import com.example.book2onandonuserservice.user.domain.entity.Role;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class PointPolicyController {
     // 1. (관리자) 정책 전체 조회
     // GET /admin/point-policies
     @GetMapping
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<List<PointPolicyResponseDto>> getAllPolicies() {
         List<PointPolicyResponseDto> pointPolicy = pointPolicyService.getAllPolicies();
         return ResponseEntity.ok(pointPolicy);
@@ -34,6 +37,7 @@ public class PointPolicyController {
     // 2. (관리자) 정책 단건 조회
     // GET /admin/point-policies/SIGNUP
     @GetMapping("/{policyName}")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<PointPolicyResponseDto> getPolicy(
             @PathVariable String policyName
     ) {
@@ -44,6 +48,7 @@ public class PointPolicyController {
     // 3. (관리자) 정책 비율/고정포인트 수정
     // PUT /admin/point-policies/1
     @PutMapping("/{policyId}")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<PointPolicyResponseDto> updatePolicy(
             @PathVariable Integer policyId,
             @Valid @RequestBody PointPolicyUpdateRequestDto dto
@@ -55,6 +60,7 @@ public class PointPolicyController {
     // 4. (관리자) 정책 활성/비활성
     // PATCH /admin/point-policies/1/active
     @PatchMapping("/{policyId}/active")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<PointPolicyResponseDto> updatePolicyActive(
             @PathVariable Integer policyId,
             @Valid @RequestBody PointPolicyActiveUpdateRequestDto dto

--- a/src/main/java/com/example/book2onandonuserservice/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/book2onandonuserservice/user/controller/AdminUserController.java
@@ -1,7 +1,9 @@
 package com.example.book2onandonuserservice.user.controller;
 
+import com.example.book2onandonuserservice.global.annotation.AuthCheck;
 import com.example.book2onandonuserservice.user.domain.dto.request.AdminUserUpdateRequestDto;
 import com.example.book2onandonuserservice.user.domain.dto.response.UserResponseDto;
+import com.example.book2onandonuserservice.user.domain.entity.Role;
 import com.example.book2onandonuserservice.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,6 +28,7 @@ public class AdminUserController {
 
     // 대시보드 회원 수 조회
     @GetMapping("/count")
+    @AuthCheck({Role.MEMBER_ADMIN, Role.BOOK_ADMIN, Role.COUPON_ADMIN, Role.ORDER_ADMIN})
     public ResponseEntity<Long> countUsers() {
         Long count = userService.countUsers();
         return ResponseEntity.ok(count);
@@ -34,6 +37,7 @@ public class AdminUserController {
 
     //전체 회원 목록 조회
     @GetMapping
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<Page<UserResponseDto>> getAllUsers(
             @PageableDefault(page = 0, size = 10, sort = "userId", direction = Sort.Direction.DESC) Pageable pageable
     ) {
@@ -43,6 +47,7 @@ public class AdminUserController {
 
     //특정 회원 상세 조회
     @GetMapping("/{userId}")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<UserResponseDto> getUserDetail(@PathVariable Long userId) {
         UserResponseDto userInfo = userService.getMyInfo(userId);
         return ResponseEntity.ok(userInfo);
@@ -50,6 +55,7 @@ public class AdminUserController {
 
     //회원 정보 수정 (권한, 상태 등급 등)
     @PutMapping("/{userId}")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<Void> updateUser(
             @PathVariable Long userId,
             @RequestBody AdminUserUpdateRequestDto request
@@ -60,6 +66,7 @@ public class AdminUserController {
 
     //회원 강제탈퇴(soft Delete)
     @DeleteMapping("/{userId}")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<Void> deleteUserByAdmin(
             @PathVariable Long userId,
             @RequestParam(required = false, defaultValue = "관리자 직권 탈퇴") String reason

--- a/src/main/java/com/example/book2onandonuserservice/user/controller/UserGradeController.java
+++ b/src/main/java/com/example/book2onandonuserservice/user/controller/UserGradeController.java
@@ -1,8 +1,10 @@
 package com.example.book2onandonuserservice.user.controller;
 
+import com.example.book2onandonuserservice.global.annotation.AuthCheck;
 import com.example.book2onandonuserservice.user.domain.dto.request.UserGradeCreateRequestDto;
 import com.example.book2onandonuserservice.user.domain.dto.request.UserGradeUpdateRequestDto;
 import com.example.book2onandonuserservice.user.domain.dto.response.UserGradeResponseDto;
+import com.example.book2onandonuserservice.user.domain.entity.Role;
 import com.example.book2onandonuserservice.user.service.UserGradeService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -25,6 +27,7 @@ public class UserGradeController {
 
     //Post 새 등급 생성
     @PostMapping("/admin/grades")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<UserGradeResponseDto> createGrade(@Valid @RequestBody UserGradeCreateRequestDto request) {
         UserGradeResponseDto response = userGradeService.createGrade(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -39,6 +42,7 @@ public class UserGradeController {
 
     //PUT /{gradeId} 등급 정보 수정
     @PutMapping("/admin/grades/{gradeId}")
+    @AuthCheck(Role.MEMBER_ADMIN)
     public ResponseEntity<UserGradeResponseDto> updateGrade(
             @PathVariable Long gradeId,
             @Valid @RequestBody UserGradeUpdateRequestDto request

--- a/src/main/java/com/example/book2onandonuserservice/user/domain/entity/Users.java
+++ b/src/main/java/com/example/book2onandonuserservice/user/domain/entity/Users.java
@@ -107,7 +107,7 @@ public class Users {
 
     public void initSocialAccount(String name, String nickname) {
         initDefaults(name, nickname);
-        this.userLoginId = "SOC_" + UUID.randomUUID().toString().substring(0, 20);
+        this.userLoginId = "PAYCO_SOC_" + UUID.randomUUID().toString().substring(0, 20);
         this.password = UUID.randomUUID().toString();
 
         String safeNickname = nickname;

--- a/src/test/java/com/example/book2onandonuserservice/Book2onandonuserserviceApplicationTests.java
+++ b/src/test/java/com/example/book2onandonuserservice/Book2onandonuserserviceApplicationTests.java
@@ -5,6 +5,7 @@ import com.example.book2onandonuserservice.global.client.BookServiceClient;
 import com.example.book2onandonuserservice.global.client.OrderServiceClient;
 import com.example.book2onandonuserservice.global.client.PaycoClient;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
@@ -46,6 +47,9 @@ class Book2onandonuserserviceApplicationTests {
 
     @MockBean
     private RedisConnectionFactory redisConnectionFactory;
+
+    @MockBean
+    private RedissonClient redissonClient;
 
     @MockBean
     private ReactiveRedisConnectionFactory reactiveRedisConnectionFactory;

--- a/src/test/java/com/example/book2onandonuserservice/aop/AuthCheckAspectTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/aop/AuthCheckAspectTest.java
@@ -1,0 +1,75 @@
+package com.example.book2onandonuserservice.aop;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.example.book2onandonuserservice.global.annotation.AuthCheck;
+import com.example.book2onandonuserservice.global.aop.AuthCheckAspect;
+import com.example.book2onandonuserservice.global.util.UserHeaderUtil;
+import com.example.book2onandonuserservice.user.domain.entity.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+class AuthCheckAspectTest {
+
+    @InjectMocks
+    private AuthCheckAspect authCheckAspect;
+
+    @Mock
+    private UserHeaderUtil userHeaderUtil;
+
+    @Test
+    @DisplayName("권한 체크 성공 - 유저가 필요한 권한을 가지고 있음")
+    void checkRole_Success() {
+        // Given
+        AuthCheck authCheck = mock(AuthCheck.class);
+        given(authCheck.value()).willReturn(new Role[]{Role.USER});
+
+        given(userHeaderUtil.getUserRole()).willReturn(Role.USER.getKey());
+
+        assertThatCode(() -> authCheckAspect.checkRole(authCheck))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("권한 체크 성공 - 슈퍼 관리자(SUPER_ADMIN)는 무조건 통과")
+    void checkRole_SuperAdmin_Pass() {
+        AuthCheck authCheck = mock(AuthCheck.class);
+        given(userHeaderUtil.getUserRole()).willReturn(Role.SUPER_ADMIN.getKey());
+
+        assertThatCode(() -> authCheckAspect.checkRole(authCheck))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("권한 체크 실패 - 헤더에 권한 정보가 없음 (로그인 안함)")
+    void checkRole_Fail_NoHeader() {
+        AuthCheck authCheck = mock(AuthCheck.class);
+        given(userHeaderUtil.getUserRole()).willReturn(null);
+
+        assertThatThrownBy(() -> authCheckAspect.checkRole(authCheck))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("권한 정보가 없습니다. (로그인 필요)");
+    }
+
+    @Test
+    @DisplayName("권한 체크 실패 - 필요한 권한이 없음")
+    void checkRole_Fail_AccessDenied() {
+        AuthCheck authCheck = mock(AuthCheck.class);
+        given(authCheck.value()).willReturn(new Role[]{Role.MEMBER_ADMIN});
+
+        given(userHeaderUtil.getUserRole()).willReturn(Role.USER.getKey());
+
+        assertThatThrownBy(() -> authCheckAspect.checkRole(authCheck))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("해당 리소스에 접근할 권한이 없습니다.");
+    }
+}

--- a/src/test/java/com/example/book2onandonuserservice/aop/DistributedLockAopTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/aop/DistributedLockAopTest.java
@@ -1,0 +1,95 @@
+package com.example.book2onandonuserservice.aop;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.book2onandonuserservice.global.annotation.DistributedLock;
+import com.example.book2onandonuserservice.global.aop.DistributedLockAop;
+import com.example.book2onandonuserservice.global.util.CustomSpringELParser;
+import java.lang.reflect.Method;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+@ExtendWith(MockitoExtension.class)
+class DistributedLockAopTest {
+    @InjectMocks
+    private DistributedLockAop distributedLockAop;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private CustomSpringELParser customSpringELParser;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @Mock
+    private MethodSignature signature;
+
+    @Mock
+    private RLock rLock;
+
+    @Test
+    @DisplayName("락 획득 성공 시 비즈니스 로직 수행 후 락 해제")
+    void lock_Success() throws Throwable {
+        Method method = TestService.class.getMethod("testMethod");
+        DistributedLock annotation = method.getAnnotation(DistributedLock.class);
+
+        given(joinPoint.getSignature()).willReturn(signature);
+        given(signature.getParameterNames()).willReturn(new String[]{});
+        given(joinPoint.getArgs()).willReturn(new Object[]{});
+
+        given(customSpringELParser.getDynamicValue(any(), any(), any())).willReturn("test-key");
+        given(redissonClient.getLock(anyString())).willReturn(rLock);
+        given(rLock.tryLock(anyLong(), anyLong(), any())).willReturn(true);
+
+        given(rLock.isLocked()).willReturn(true);
+        given(rLock.isHeldByCurrentThread()).willReturn(true);
+
+        given(joinPoint.proceed()).willReturn(null);
+
+        // when
+        distributedLockAop.lock(joinPoint, annotation);
+
+        // then
+        verify(rLock).tryLock(anyLong(), anyLong(), any());
+        verify(joinPoint).proceed();
+        verify(rLock).unlock();
+    }
+
+
+    @Test
+    @DisplayName("락 획득 실패 시 예외 발생")
+    void lock_Fail() throws Throwable {
+        Method method = TestService.class.getMethod("testMethod");
+        DistributedLock annotation = method.getAnnotation(DistributedLock.class);
+
+        given(joinPoint.getSignature()).willReturn(signature);
+        given(customSpringELParser.getDynamicValue(any(), any(), any())).willReturn("test-key");
+        given(redissonClient.getLock(anyString())).willReturn(rLock);
+        given(rLock.tryLock(anyLong(), anyLong(), any())).willReturn(false); // 락 획득 실패
+
+        assertThatThrownBy(() -> distributedLockAop.lock(joinPoint, annotation))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    static class TestService {
+        @DistributedLock(key = "test")
+        public void testMethod() {
+            throw new UnsupportedOperationException("This method is intentionally not implemented.");
+        }
+    }
+}

--- a/src/test/java/com/example/book2onandonuserservice/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/controller/AuthControllerTest.java
@@ -16,6 +16,7 @@ import com.example.book2onandonuserservice.auth.domain.dto.request.FindIdRequest
 import com.example.book2onandonuserservice.auth.domain.dto.request.FindPasswordRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.request.LocalSignUpRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.request.LoginRequestDto;
+import com.example.book2onandonuserservice.auth.domain.dto.request.ReissueRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.response.FindIdResponseDto;
 import com.example.book2onandonuserservice.auth.domain.dto.response.TokenResponseDto;
 import com.example.book2onandonuserservice.auth.service.AuthService;
@@ -241,4 +242,23 @@ class AuthControllerTest {
         verify(authService).unlockDormantAccount(email, code);
     }
 
+    @Test
+    @DisplayName("토큰 재발급 성공 (200 OK)")
+    void reissue_Success() throws Exception {
+        ReissueRequestDto request = new ReissueRequestDto("expired-access-token", "valid-refresh-token");
+
+        TokenResponseDto response = new TokenResponseDto("new-access-token", "new-refresh-token", "Bearer", 3600L);
+
+        given(authService.reissue(any(ReissueRequestDto.class))).willReturn(response);
+
+        mockMvc.perform(post("/auth/reissue")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh-token"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"));
+    }
 }

--- a/src/test/java/com/example/book2onandonuserservice/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/exception/GlobalExceptionHandlerTest.java
@@ -78,6 +78,16 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
+    // [401] Refresh Token 유효성 검사 실패 테스트
+    @Test
+    @DisplayName("InvalidRefreshTokenException 발생 시 401 반환 (INVALID_REFRESH_TOKEN)")
+    void handleInvalidRefreshToken_returns401() throws Exception {
+        mockMvc.perform(get("/test/invalid-refresh-token"))
+                .andExpect(status().isUnauthorized()) // 401 확인
+                .andExpect(jsonPath("$.error", is("INVALID_REFRESH_TOKEN"))) // 에러 코드 확인
+                .andExpect(jsonPath("$.message", is("유효하지 않은 RefreshToken입니다.")));
+    }
+
     // [403] 권한 없음/휴면 테스트
     @Test
     @DisplayName("휴면 계정 접속 시 403 반환")

--- a/src/test/java/com/example/book2onandonuserservice/exception/TestExceptionController.java
+++ b/src/test/java/com/example/book2onandonuserservice/exception/TestExceptionController.java
@@ -1,6 +1,7 @@
 package com.example.book2onandonuserservice.exception;
 
 import com.example.book2onandonuserservice.auth.exception.AuthenticationFailedException;
+import com.example.book2onandonuserservice.auth.exception.InvalidRefreshTokenException;
 import com.example.book2onandonuserservice.auth.exception.PaycoServerException;
 import com.example.book2onandonuserservice.point.exception.InvalidPointPolicyException;
 import com.example.book2onandonuserservice.point.exception.SignupPointAlreadyGrantedException;
@@ -42,6 +43,12 @@ public class TestExceptionController {
     @GetMapping("/auth-failed")
     public void authFailed() {
         throw new AuthenticationFailedException();
+    }
+
+    // 401: Refresh Token 유효성 검사 실패
+    @GetMapping("/invalid-refresh-token")
+    public void invalidRefreshToken() {
+        throw new InvalidRefreshTokenException("유효하지 않은 RefreshToken입니다.");
     }
 
     // 403: 휴면 계정

--- a/src/test/java/com/example/book2onandonuserservice/service/AuthServiceImplTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/service/AuthServiceImplTest.java
@@ -14,7 +14,9 @@ import com.example.book2onandonuserservice.auth.domain.dto.request.FindIdRequest
 import com.example.book2onandonuserservice.auth.domain.dto.request.FindPasswordRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.request.LocalSignUpRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.request.LoginRequestDto;
+import com.example.book2onandonuserservice.auth.domain.dto.request.ReissueRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.response.FindIdResponseDto;
+import com.example.book2onandonuserservice.auth.domain.dto.response.TokenResponseDto;
 import com.example.book2onandonuserservice.auth.domain.entity.UserAuth;
 import com.example.book2onandonuserservice.auth.exception.AuthenticationFailedException;
 import com.example.book2onandonuserservice.auth.repository.jpa.UserAuthRepository;
@@ -110,6 +112,35 @@ class AuthServiceImplTest {
         authService.logout("accessToken");
         verify(authTokenService).logout("accessToken");
     }
+
+    // 토큰 재발급 테스트
+    @Test
+    @DisplayName("재발급 성공 - AuthTokenService에 위임하고 결과 반환")
+    void reissue_success() {
+        ReissueRequestDto request = new ReissueRequestDto("oldAccessToken", "oldRefreshToken");
+        TokenResponseDto expected = mock(TokenResponseDto.class);
+
+        when(authTokenService.reissueToken(request)).thenReturn(expected);
+
+        TokenResponseDto result = authService.reissue(request);
+
+        assertThat(result).isSameAs(expected);
+        verify(authTokenService).reissueToken(request);
+    }
+
+    @Test
+    @DisplayName("재발급 실패 - AuthTokenService에서 예외 발생 시 그대로 전파")
+    void reissue_fail_propagateException() {
+        ReissueRequestDto request = new ReissueRequestDto("oldAccessToken", "oldRefreshToken");
+
+        when(authTokenService.reissueToken(request))
+                .thenThrow(new RuntimeException("토큰 재발급 실패"));
+
+        assertThatThrownBy(() -> authService.reissue(request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("토큰 재발급 실패");
+    }
+
 
     // 로컬 회원가입 테스트
     @Test

--- a/src/test/java/com/example/book2onandonuserservice/service/AuthTokenServiceTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/service/AuthTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.book2onandonuserservice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -9,15 +10,18 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.example.book2onandonuserservice.auth.domain.dto.request.ReissueRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.request.TokenRequestDto;
 import com.example.book2onandonuserservice.auth.domain.dto.response.TokenResponseDto;
 import com.example.book2onandonuserservice.auth.domain.entity.RefreshToken;
+import com.example.book2onandonuserservice.auth.exception.InvalidRefreshTokenException;
 import com.example.book2onandonuserservice.auth.jwt.JwtTokenProvider;
 import com.example.book2onandonuserservice.auth.repository.redis.RefreshTokenRepository;
 import com.example.book2onandonuserservice.auth.service.AuthTokenService;
 import com.example.book2onandonuserservice.global.util.RedisUtil;
 import com.example.book2onandonuserservice.user.domain.entity.Role;
 import com.example.book2onandonuserservice.user.domain.entity.Users;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +66,78 @@ class AuthTokenServiceTest {
 
         verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void reissueToken_Success() {
+        String oldAccessToken = "old-access-token";
+        String oldRefreshToken = "old-refresh-token";
+        String userId = "1";
+        String role = "ROLE_USER";
+
+        ReissueRequestDto requestDto = new ReissueRequestDto(oldAccessToken, oldRefreshToken);
+
+        given(jwtTokenProvider.validateToken(oldRefreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserId(oldRefreshToken)).willReturn(userId);
+        RefreshToken storedToken = new RefreshToken(userId, oldRefreshToken);
+        given(refreshTokenRepository.findById(userId)).willReturn(Optional.of(storedToken));
+        given(jwtTokenProvider.getRole(oldRefreshToken)).willReturn(role);
+
+        TokenResponseDto newTokens = new TokenResponseDto("new-acc", "new-ref", "Bearer", 3600L);
+        given(jwtTokenProvider.createTokens(any(TokenRequestDto.class))).willReturn(newTokens);
+
+        TokenResponseDto result = authTokenService.reissueToken(requestDto);
+
+        assertThat(result.accessToken()).isEqualTo("new-acc");
+        assertThat(result.refreshToken()).isEqualTo("new-ref");
+
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 유효하지 않은 RefreshToken")
+    void reissueToken_Fail_InvalidToken() {
+        ReissueRequestDto requestDto = new ReissueRequestDto("acc", "invalid-ref");
+
+        given(jwtTokenProvider.validateToken("invalid-ref")).willReturn(false);
+
+        assertThatThrownBy(() -> authTokenService.reissueToken(requestDto))
+                .isInstanceOf(InvalidRefreshTokenException.class) // 변경됨
+                .hasMessage("유효하지 않은 RefreshToken입니다.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - Redis에 저장된 토큰 없음(만료 등)")
+    void reissueToken_Fail_TokenNotFound() {
+        ReissueRequestDto requestDto = new ReissueRequestDto("acc", "valid-ref");
+        String userId = "1";
+
+        given(jwtTokenProvider.validateToken("valid-ref")).willReturn(true);
+        given(jwtTokenProvider.getUserId("valid-ref")).willReturn(userId);
+        given(refreshTokenRepository.findById(userId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authTokenService.reissueToken(requestDto))
+                .isInstanceOf(InvalidRefreshTokenException.class) // 변경됨
+                .hasMessage("저장된 Refresh 토큰이 없습니다. 다시 로그인 하세요.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 요청 토큰과 저장된 토큰 불일치")
+    void reissueToken_Fail_TokenMismatch() {
+        ReissueRequestDto requestDto = new ReissueRequestDto("acc", "request-ref");
+        String userId = "1";
+
+        given(jwtTokenProvider.validateToken("request-ref")).willReturn(true);
+        given(jwtTokenProvider.getUserId("request-ref")).willReturn(userId);
+
+        RefreshToken storedToken = new RefreshToken(userId, "different-stored-ref");
+        given(refreshTokenRepository.findById(userId)).willReturn(Optional.of(storedToken));
+
+        assertThatThrownBy(() -> authTokenService.reissueToken(requestDto))
+                .isInstanceOf(InvalidRefreshTokenException.class) // 변경됨
+                .hasMessage("RefreshToken이 일치하지 않습니다.");
+    }
+
 
     @Test
     @DisplayName("로그아웃 성공 - 토큰 유효시간이 남은 경우 블랙리스트 등록 및 DB 삭제")

--- a/src/test/java/com/example/book2onandonuserservice/util/CustomSpringELParserTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/util/CustomSpringELParserTest.java
@@ -1,0 +1,76 @@
+package com.example.book2onandonuserservice.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.book2onandonuserservice.global.util.CustomSpringELParser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CustomSpringELParserTest {
+
+    private final CustomSpringELParser parser = new CustomSpringELParser();
+
+    @Test
+    @DisplayName("단일 변수 SpEL 파싱 테스트")
+    void testSingleVariableParsing() {
+        // given
+        String[] paramNames = {"userId"};
+        Object[] args = {12345L};
+        String spel = "#userId";
+
+        // when
+        Object result = parser.getDynamicValue(paramNames, args, spel);
+
+        // then
+        assertThat(result).isEqualTo(12345L);
+    }
+
+    @Test
+    @DisplayName("여러 변수를 포함한 SpEL 파싱 테스트")
+    void testMultipleVariableParsing() {
+        // given
+        String[] paramNames = {"userId", "orderId"};
+        Object[] args = {10L, 999L};
+        String spel = "T(String).valueOf(#userId) + '-' + T(String).valueOf(#orderId)";
+
+        // when
+        Object result = parser.getDynamicValue(paramNames, args, spel);
+
+        // then
+        assertThat(result).isEqualTo("10-999");
+    }
+
+    @Test
+    @DisplayName("객체 값을 전달받아 SpEL로 필드 접근 테스트")
+    void testObjectFieldParsing() {
+        // given
+        class Dummy {
+            public String name = "testUser";
+        }
+
+        String[] paramNames = {"dummy"};
+        Object[] args = {new Dummy()};
+        String spel = "#dummy.name";
+
+        // when
+        Object result = parser.getDynamicValue(paramNames, args, spel);
+
+        // then
+        assertThat(result).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 변수 사용 시 null 반환 테스트")
+    void testInvalidVariable() {
+        // given
+        String[] paramNames = {"a"};
+        Object[] args = {1};
+        String spel = "#b"; // 존재하지 않음
+
+        // when
+        Object result = parser.getDynamicValue(paramNames, args, spel);
+
+        // then
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/example/book2onandonuserservice/util/UserHeaderUtilTest.java
+++ b/src/test/java/com/example/book2onandonuserservice/util/UserHeaderUtilTest.java
@@ -1,0 +1,86 @@
+package com.example.book2onandonuserservice.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.book2onandonuserservice.global.util.UserHeaderUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class UserHeaderUtilTest {
+
+    private UserHeaderUtil userHeaderUtil;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        userHeaderUtil = new UserHeaderUtil();
+        request = new MockHttpServletRequest();
+        // MockRequest를 ContextHolder에 등록
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+
+    @Test
+    @DisplayName("User ID 가져오기 성공 - 헤더에 유효한 ID가 있을 때")
+    void getUserId_Success() {
+        request.addHeader("X-User-Id", "12345");
+        Long userId = userHeaderUtil.getUserId();
+        assertThat(userId).isEqualTo(12345L);
+    }
+
+    @Test
+    @DisplayName("User ID 가져오기 실패 - 헤더 값이 숫자가 아님 (NumberFormatException)")
+    void getUserId_Fail_NotNumber() {
+        request.addHeader("X-User-Id", "invalid-id");
+        Long userId = userHeaderUtil.getUserId();
+        assertThat(userId).isNull();
+    }
+
+    @Test
+    @DisplayName("User ID 가져오기 실패 - 헤더가 없거나 비어있음")
+    void getUserId_Fail_EmptyHeader() {
+        Long userId = userHeaderUtil.getUserId();
+        assertThat(userId).isNull();
+    }
+
+    @Test
+    @DisplayName("User ID 가져오기 실패 - 요청 컨텍스트가 없음 (Request is null)")
+    void getUserId_Fail_NoRequest() {
+        RequestContextHolder.resetRequestAttributes();
+        Long userId = userHeaderUtil.getUserId();
+        assertThat(userId).isNull();
+    }
+
+    @Test
+    @DisplayName("User Role 가져오기 성공")
+    void getUserRole_Success() {
+        request.addHeader("X-User-Role", "ROLE_USER");
+        String role = userHeaderUtil.getUserRole();
+        assertThat(role).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("User Role 가져오기 실패 - 헤더 없음")
+    void getUserRole_Fail_NoHeader() {
+        String role = userHeaderUtil.getUserRole();
+        assertThat(role).isNull();
+    }
+
+    @Test
+    @DisplayName("User Role 가져오기 실패 - 요청 컨텍스트 없음")
+    void getUserRole_Fail_NoRequest() {
+        RequestContextHolder.resetRequestAttributes();
+        String role = userHeaderUtil.getUserRole();
+        assertThat(role).isNull();
+    }
+}


### PR DESCRIPTION
## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.
- 백엔드 API 권한 체크를 위한 Custom Annotation(@AuthCheck) 및 AOP 적용
-  Access Token 만료 시 갱신을 위한 재발급(Reissue) API 구현

예시:

- 로그인 API 응답 포맷 수정
- 도서 상세 페이지 스타일링 개선

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

1. 권한 체크 AOP 적용
   -  메서드 단위로 권한을 설정할 수 있는 어노테이션 추가
   - 요청 헤더의 User Role을 확인하여 접근 권한을 검증하는 AOP 로직 구현 (SUPER_ADMIN은 프리패스)
2. 토큰 재발급 API 구현
   - /auth/reissue 엔드포인트 추가 및 authService.reissue() 연동


- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.
- API 별로 사용자의 역할(Role)에 따라 접근을 제어하는 보안 로직을 공통화하여 중복 코드를 제거하고 보안을 강화하기 위함.
- 클라이언트에서 Access Token 만료 시 로그아웃되지 않고 토큰을 갱신할 수 있는 수단이 필요함.

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  
#101 

---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.

예시:

```bash
# 로컬 서버 실행
npm run dev
# 또는
python manage.py runserver
